### PR TITLE
Hub projects

### DIFF
--- a/app.js
+++ b/app.js
@@ -266,6 +266,15 @@ app.get('/ida', function(req, res) {
 
 });
 
+
+//hub url shortcuts
+app.get('/hub/:hub_url', function(req, res) {
+
+    console.log(req.params.hub_url)
+    var link = "/kioskProject.html#/hubPage/" + req.params.hub_url;
+    res.redirect(link); // send to hub page
+});
+
 //healthy gulf event: algal Blooms
 app.get('/hg', function(req, res) {
     var project_code = "ChAkLfwYIBgo";

--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ var os = require('os');
 var users = require('./routes/users');
 var login = require('./routes/login');
 var projectsApi = require('./routes/projects');
+var hubProjectsApi = require('./routes/hubProjects');
 var taskApi = require('./routes/tasks');
 var session = require('express-session');
 var anonApi = require('./routes/anonUser');
@@ -102,6 +103,7 @@ passport.deserializeUser(function(user, done) {
 
 app.use('/api/user', users);
 app.use('/api/project', projectsApi);
+app.use('/api/hub', hubProjectsApi);
 app.use('/api/', login);
 app.use('/api/tasks', taskApi);
 app.use('/api/anon', anonApi);

--- a/database_migrations/dump.sql
+++ b/database_migrations/dump.sql
@@ -283,6 +283,32 @@ CREATE TABLE `projects` (
 ) ENGINE=InnoDB AUTO_INCREMENT=31 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
+
+--
+-- Table structure for table `hub_projects`
+--
+
+DROP TABLE IF EXISTS `hub_projects`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `hub_projects` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(512) DEFAULT NULL,
+  `description` varchar(2048) DEFAULT NULL,
+  `url_name` varchar(512) DEFAULT NULL,
+  `hub_unique_code` varchar(255) DEFAULT NULL,
+  `hub_dataset_id` varchar(45) DEFAULT NULL,
+  `external_sign_up` text,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `last_modified` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `project_codes` varchar(512) DEFAULT NULL,
+  `results_labels` TEXT DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `url_name_UNIQUE` (`url_name`)
+) ENGINE=InnoDB CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+
 --
 -- Table structure for table `response`
 --

--- a/database_migrations/dump.sql
+++ b/database_migrations/dump.sql
@@ -293,15 +293,18 @@ DROP TABLE IF EXISTS `hub_projects`;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `hub_projects` (
   `id` int NOT NULL AUTO_INCREMENT,
+  `creatorID` int DEFAULT NULL,
+  `cover_pic` varchar(255) DEFAULT NULL,
   `name` varchar(512) DEFAULT NULL,
   `description` varchar(2048) DEFAULT NULL,
   `url_name` varchar(512) DEFAULT NULL,
   `hub_unique_code` varchar(255) DEFAULT NULL,
-  `hub_dataset_id` varchar(45) DEFAULT NULL,
+  `published` int DEFAULT '0',
   `external_sign_up` text,
   `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
   `last_modified` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `project_codes` varchar(512) DEFAULT NULL,
+  `dataset_ids` TEXT DEFAULT NULL,
   `results_labels` TEXT DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `url_name_UNIQUE` (`url_name`)

--- a/db/hubProject.js
+++ b/db/hubProject.js
@@ -1,0 +1,84 @@
+ var db = require('../db/db');
+ var Promise = require('bluebird');
+ var fs = require('fs');
+ var path = require('path');
+ var databaseName = process.env.CARTO_DB_NAME;
+
+exports.addHubProject = function(name, userID, desc, picID, uniqueCode, url_name,external_sign_up) {
+    return new Promise(function(resolve, reject) {
+  
+      var connection = db.get();
+      connection.queryAsync('INSERT INTO hub_projects (name,creatorID,description,cover_pic,hub_unique_code,url_name,external_sign_up) VALUES(?,?,?,?,?,?,?)',
+        [name, userID, desc, picID, uniqueCode,url_name,external_sign_up]).then(
+        function(result) {
+          resolve(result);
+        }).catch(function(err) {
+        reject(err);
+      });
+    });
+  };
+
+  exports.publish = function(hub_unique_code) {
+    return new Promise(function(resolve, error) {
+      var connection = db.get();
+      connection.queryAsync('UPDATE hub_projects SET published=1 WHERE hub_unique_code=?',
+        [hub_unique_code]).then(
+        function(data) {
+          resolve(data);
+        }, function(err) {
+          error(err);
+        });
+    });
+  };
+  
+
+exports.getHubFromCode = function(hubUniqueCode) {
+    return new Promise(function(resolve, error) {
+      var connection = db.get();
+      connection.queryAsync('SELECT * from hub_projects WHERE hub_unique_code=?',
+        [hubUniqueCode]).then(
+        function(data) {
+          resolve(data);
+        }, function(err) {
+          error(err);
+        });
+    });
+  };
+
+
+  exports.getAllHubProjectsForUser = function(userID) {
+    return new Promise(function(resolve, error) {
+      var connection = db.get();
+      connection.queryAsync('select * from '+databaseName+'.`hub_projects` WHERE `creatorId`=?',
+        [userID]).then(
+        function(data) {
+          resolve(data);
+        }, function(err) {
+          error(err);
+        });
+    });
+  };
+
+
+
+exports.addSubprojectItems = function(hub_code,subproject_items,categories_items) {
+    return new Promise(function(resolve, error) {
+      var connection = db.get();
+
+      var subproject_ids = [];
+      var dataset_ids = [];
+      //we need to store ids, dataset ids and unique codes
+      subproject_items.forEach(function(item){
+        subproject_ids.push(item.id)
+        dataset_ids.push(item.dataset_id)
+      })
+
+      connection.queryAsync('update hub_projects set dataset_ids=?,project_codes=?,results_labels=? WHERE hub_unique_code=?',
+        [dataset_ids.join(","),subproject_ids.join(","),categories_items.join(","),hub_code]).then(
+        function(data) {
+          resolve(data);
+        }, function(err) {
+          error(err);
+        });
+    });
+  };

--- a/db/hubProject.js
+++ b/db/hubProject.js
@@ -18,6 +18,19 @@ exports.addHubProject = function(name, userID, desc, picID, uniqueCode, url_name
     });
   };
 
+  exports.editHubProject = function(name, desc, picID, uniqueCode, url_name,external_sign_up) {
+    return new Promise(function(resolve, reject) {
+      var connection = db.get();
+      connection.queryAsync('update hub_projects set name=? , description=?, cover_pic=?, url_name=?, external_sign_up=? where hub_unique_code=?',
+        [name, desc, picID,url_name,external_sign_up,uniqueCode]).then(
+        function(result) {
+          resolve(result);
+        }).catch(function(err) {
+        reject(err);
+      });
+    });
+  };
+
   exports.publish = function(hub_unique_code) {
     return new Promise(function(resolve, error) {
       var connection = db.get();
@@ -37,6 +50,19 @@ exports.getHubFromCode = function(hubUniqueCode) {
       var connection = db.get();
       connection.queryAsync('SELECT * from hub_projects WHERE hub_unique_code=?',
         [hubUniqueCode]).then(
+        function(data) {
+          resolve(data);
+        }, function(err) {
+          error(err);
+        });
+    });
+  };
+
+  exports.getHubFromURL = function(hubURL) {
+    return new Promise(function(resolve, error) {
+      var connection = db.get();
+      connection.queryAsync('SELECT * from hub_projects WHERE url_name=?',
+        [hubURL]).then(
         function(data) {
           resolve(data);
         }, function(err) {

--- a/db/project.js
+++ b/db/project.js
@@ -220,6 +220,20 @@ exports.getProjectFromCode = function(uniqueCode) {
 };
 
 
+exports.getHubFromCode = function(hubUniqueCode) {
+  return new Promise(function(resolve, error) {
+    var connection = db.get();
+    connection.queryAsync('SELECT * from hub_projects WHERE hub_unique_code=?',
+      [hubUniqueCode]).then(
+      function(data) {
+        resolve(data);
+      }, function(err) {
+        error(err);
+      });
+  });
+};
+
+
 exports.getProjectFromCodeUnPub = function(uniqueCode) {
     return new Promise(function(resolve, error) {
         var connection = db.get();

--- a/db/project.js
+++ b/db/project.js
@@ -220,18 +220,6 @@ exports.getProjectFromCode = function(uniqueCode) {
 };
 
 
-exports.getHubFromCode = function(hubUniqueCode) {
-  return new Promise(function(resolve, error) {
-    var connection = db.get();
-    connection.queryAsync('SELECT * from hub_projects WHERE hub_unique_code=?',
-      [hubUniqueCode]).then(
-      function(data) {
-        resolve(data);
-      }, function(err) {
-        error(err);
-      });
-  });
-};
 
 
 exports.getProjectFromCodeUnPub = function(uniqueCode) {

--- a/db/results.js
+++ b/db/results.js
@@ -418,6 +418,67 @@ exports.getRawResultsMultiplebyTextGrouped = function(project_ids,dataset_id,inc
 
 }
 
+
+exports.getHubRawResultsMultiplebyTextGrouped = function(project_ids,dataset_id,include_mturk){
+    return new Promise(function(resolve, error) {
+        var connection = db.get();
+
+        var query = 'select r.task_id,r.project_id,r.response_text as answer,p.unique_code,p.name,d.x,d.y  ,count(*) as votes from response as r left join projects as p on p.id=r.project_id ' +
+            'left join dataset_' + dataset_id + ' as d on d.name=r.task_id where r.project_id in ('+ project_ids.toString() + ' ) and task_id!=\'dummy\'  group by task_id,x,y,project_id,response_text '
+
+        //make sure we exclude mturk workers if asked
+        if (!include_mturk){
+            query = 'select v.task_id,v.project_id,v.answer,v.unique_code,v.name,v.x,v.y,count(*) as votes from ' +
+                '(select r.task_id,r.project_id,r.response_text as answer,p.unique_code,p.name,d.x,d.y,k.hitID,r.user_id  from response as r left join projects as p on p.id=r.project_id ' +
+                'left join dataset_'+ dataset_id + '  as d on d.name=r.task_id left join kiosk_workers as k on r.user_id=k.workerID where k.hitID=\'kiosk\' and r.project_id in (' +  project_ids.toString() + ') ' +
+                'and task_id!=\'dummy\' and DATE(timestamp) >= \'2020-09-23\' ) as v group by task_id,x,y,project_id,answer '
+        }
+
+        var grouped_data = {};
+
+
+        var today = new Date();
+        var dd = today.getDate().toString();
+        var mm = (today.getMonth() + 1).toString();  //January is 0!
+        var yyyy = today.getFullYear().toString();
+
+        var current_date = mm + '/' + dd + '/' + yyyy;
+
+
+        connection.queryAsync(query).then(
+            function(data) {
+
+                data.forEach(function(item){
+                    if (!grouped_data.hasOwnProperty(item.task_id)){
+                        grouped_data[item.task_id] = {}
+                    };
+                    if (!grouped_data[item.task_id].hasOwnProperty(item.project_id)){
+                        grouped_data[item.task_id][item.project_id] = {
+                            total:0,
+                            majority: item.answer,
+                            majority_count: item.votes,
+                            unique_code: item.unique_code,
+                            dataset_id: dataset_id,
+                            lat: item.x,
+                            lon: item.y,
+                            image_url: 'cartosco.pe/api/tasks/getImageFree/' + dataset_id + '/' + item.task_id  + '.jpg',
+                            date_pulled: current_date}
+                    }
+                    grouped_data[item.task_id][item.project_id][item.answer] = item.votes;
+                    grouped_data[item.task_id][item.project_id].total += item.votes;
+                    if (item.votes > grouped_data[item.task_id][item.project_id].majority_count  ) {
+                        grouped_data[item.task_id][item.project_id].majority_count = item.votes;
+                        grouped_data[item.task_id][item.project_id].majority = item.answer
+                    }
+                });
+                resolve(grouped_data)
+            }, function(err) {
+                error(err);
+            });
+    });
+
+}
+
 exports.getRawResultsMultiplebyText = function(project_ids){
     return new Promise(function(resolve, error) {
         var connection = db.get();

--- a/public/hubResults.html
+++ b/public/hubResults.html
@@ -1,0 +1,94 @@
+<div class="container" ng-controller="resultsHubController">
+    <center>
+
+
+        <div class="row">
+            <h1 style="color: black">Results & Contributions</h1>
+        </div>
+
+        <div class="row" ng-show="successProject">
+            <p> Below you can see how other people have contributed to the project. You can see results
+                by answer by clicking on the buttons below. Zoom in for more detailed results. You can also click on any marker to get more information on the corresponding image.
+            </p>
+        </div>
+
+        <div class="row" >
+
+            <!--</div>-->
+            <div id="map_canvas" ng-if="successProject">
+
+                <ui-gmap-google-map center="map1.center" zoom="map1.zoom" draggable="true" options="options" bounds="map1.bounds">
+                    <!--<ui-gmap-markers  ng-hide="showMarkers" models="workerResultsTransformed" coords="'self'" icon="'icon'" events="map1.markersEvents">-->
+
+                    <!--<ui-gmap-windows show="'showWindow'" closeClick="'closeClick'" templateUrl="'templateUrl'" templateParameter="'templateParameter'" ng-cloak>-->
+                    <!--</ui-gmap-windows>-->
+                    <!--</ui-gmap-markers>-->
+
+
+                    <ui-gmap-markers models="hubMarkers" coords="'self'" icon="'icon'" events="map1.markersEvents">
+
+                        <ui-gmap-windows show="'showWindow'" closeClick="'closeClick'" templateUrl="'templateUrl'" templateParameter="'templateParameter'" ng-cloak>
+                        </ui-gmap-windows>
+                    </ui-gmap-markers>
+
+                </ui-gmap-google-map>
+            </div>
+        </div>
+
+
+
+        <div ng-show="showMap" class="row">
+
+            <h3> Use the buttons below to pick a pattern and explore where it has been identified so far!  </h3>
+
+            <button class="btn-lg  " placeholder="Option" ng-repeat="option in hub_positives_buttons track by $index "
+
+                    style=" margin-right:10px;
+                    background-color: {{option.active ? option.color : 'white'}};
+                    border-color: {{hex_array[$index]}};
+                   border:2px solid {{hex_array[$index]}}; "
+                    ng-click="update_hub_Markers(option.pattern,$index)">{{option.pattern}}</button>
+        </div>
+
+        <br>
+
+
+
+
+
+        <div class="row" ng-hide="successProject">
+                <h2>Results loading...</h2>
+        </div>
+
+        <div class="row" ng-if="external_signup">
+            <div class="col-md-1"></div>
+            <div class="col-md-10">
+                <h3>Would you like to participate in other projects like this or learn more about environmental issues along the Gulf or Mexico?
+                    Fill in this information to sign up. Make sure to hit the blue Submit button to complete the sign up!</h3>
+                <iframe id="iframe_div2"
+                            ng-src="{{getExternalFrame(external_signup)}}"
+                        style="width: 100%;height:600px" >
+                </iframe>
+            </div>
+            <div class="col-md-1"></div>
+        </div>
+
+
+
+        <div class="row">
+                <h3>Click below to export results:</h3>
+                <div ng-show="successProject">
+                    <button class="submit-button" ng-click="downloadCSVHub()" style="margin-top: 20px;
+            border-radius: 8px;
+            background-color: #9cdc1f;
+            color: #000;
+            font-size: 18px;
+            text-align: center;
+            outline: none;
+            border: none;
+            padding: 10px 25px;">Download Results</button>
+                </div>
+            </div>
+    </center>
+
+</div>

--- a/public/script/app.js
+++ b/public/script/app.js
@@ -416,13 +416,13 @@ module.config(function($stateProvider, $urlRouterProvider, $httpProvider) {
           });
 
 
-          if ($scope.project.hasOwnProperty('scistarter_link')){
+          if ($scope.project.hasOwnProperty('scistarter_link') && $scope.project.scistarter_link ){
               $scope.has_scistarter = true;
           }
           if ($scope.project.is_inaturalist) {
               $scope.project.is_inaturalist = true;
           }
-          if ($scope.project.hasOwnProperty("external_sign_up")){
+          if ($scope.project.hasOwnProperty("external_sign_up") && $scope.project.external_sign_up){
                 $scope.has_external_signup = true;
           }
 
@@ -775,6 +775,57 @@ module.config(function($stateProvider, $urlRouterProvider, $httpProvider) {
       }
     }
   });
+
+  $stateProvider.state({
+    name: 'root.hubEdit',
+    url: '/hub/edit/:hubCode',
+    templateUrl: 'templates/userProfile/hubEditTemplate.html',
+    params: {
+      hub: null
+    },
+    controller: 'hubEditController',
+    abstract: true,
+    resolve: {
+      hub: ['$stateParams', '$q', '$http', function($stateParams, $q, $http) {
+
+        return $q(function(resolve, reject) {
+          if ($stateParams.hub && $stateParams.hub.hub_unique_code) {
+            resolve($stateParams.hub);
+          } else {
+            $http.get('/api/projects/getHubInfo/' + $stateParams.hub.hub_unique_code).then(function(data) {
+              resolve(data.data);
+            }).catch(function(error) {
+              reject('server error');
+            });
+          }
+        });
+      }]
+    }
+  });
+
+
+  $stateProvider.state({
+    name: 'root.hubEdit.step1',
+    url: '/hubStep1',
+    views: {
+      'createProjChildView': {
+        templateUrl: 'templates/userProfile/hubProjectCreation/step1.html',
+        controller: 'hubStepOneEditController'
+      }
+    }
+  });
+
+  $stateProvider.state({
+    name: 'root.hubEdit.step2',
+    url: '/hubStep2',
+    views: {
+      'createProjChildView': {
+        templateUrl: 'templates/userProfile/hubProjectCreation/step2.html',
+        controller: 'hubStepTwoEditController'
+      }
+    }
+  });
+
   
 
 
@@ -2249,7 +2300,7 @@ module.controller('hubsPageController', ['$scope', 'userData', 'hubs', '$timeout
 
     //Edit Hubs
     $scope.goToHubEdit = function(hub) {
-      $state.go('root.hubProjectEdit.step1', {hub: hub, id: hub.id});
+      $state.go('root.hubEdit.step1', {hub: hub});
     };
 
 
@@ -2318,9 +2369,6 @@ module.controller('hubProjectCreationController', ['$scope', '$http', '$state', 
       return $scope.hub.can_be_published  ;
     };
 
-    $scope.verifyCanImportData = function() {
-      return $scope.project.id && $scope.project.templateSaved;
-    };
 
     $scope.openPublishPopup = function() {
       if ($scope.verifyCanPublish()) {
@@ -2367,8 +2415,6 @@ module.controller('hubStepOneController', ['$scope', '$state', '$http', 'swalSer
     });
 
     $scope.validate = function() {
-
-
       if (!$scope.hub.name || !$scope.hub.description || !$scope.hub.url_name) {
         $scope.showErr = true;
         swalService.showErrorMsg('Please enter a name, a url name and description for the  hub project.');
@@ -2385,8 +2431,10 @@ module.controller('hubStepOneController', ['$scope', '$state', '$http', 'swalSer
       }
     };
 
+    
+
     $scope.createHubProject = function() {
-      if ($scope.hub.id) {
+      if ($scope.hub.id ) {
         $scope.$emit('moveNext');
       } else {
         var fd = new FormData();
@@ -2400,8 +2448,8 @@ module.controller('hubStepOneController', ['$scope', '$state', '$http', 'swalSer
               fd.append('external_sign_up', $scope.hub.external_sign_up);
           }
 
-
-          $http.post('/api/hub/add', fd, {
+          var link = '/api/hub/add'
+          $http.post(link, fd, {
           transformRequest: angular.identity,
           headers: {'Content-Type': undefined}
         }).then(function(response) {
@@ -2549,7 +2597,287 @@ module.controller('hubStepOneController', ['$scope', '$state', '$http', 'swalSer
   }]);
 
 
+  module.controller('hubEditController', ['$scope', '$http', '$state','$timeout', 'swalService', 'hub',
+  function($scope, $http, $state,$timeout, swalService, hub) {
+    $scope.hub = hub;
 
+    if (!$scope.hub.editing) {
+      $scope.hub.editing = true;
+    }
+
+    $scope.goTo = function(to) {
+      if ($scope.hub.id) {
+        $state.go(to);
+      }
+    };
+
+    $scope.isActive = function(stateName) {
+      return $state.current && $state.current.name == stateName;
+    };
+
+    $scope.getNextText = function() {
+      return 'Save';
+    };
+    $scope.goNext = function() {
+
+      if ($state.current && $state.current.name == 'root.hubEdit.step2') {
+        $scope.openPublishPopup();
+      } else {
+        $scope.$broadcast('validate');
+      }
+    };
+
+    $scope.$on('HubMoveNext', function(e, d) {
+      var curr = $state.current.name;
+      console.log(curr)
+      var stateMap = {
+        'root.hubEdit.step1': 'root.hubEdit.step2',
+      };
+      try {
+        $state.go(stateMap[curr], {hub: $scope.hub});
+      }
+      catch (e) {
+        console.log(e)
+
+      }
+    });
+    
+    $scope.verifyCanPublish = function() {
+      return $scope.hub.can_be_published  ;
+    };
+
+
+    $scope.openPublishPopup = function() {
+      if ($scope.verifyCanPublish()) {
+        $('#publishPopup').modal('show');
+      } else {
+        swalService.showErrorMsg('Please make sure you\'ve filled up the required details before you try to publish.');
+      }
+    };
+
+    $scope.publish = function() {
+      if ($scope.hub.hub_unique_code) {
+        $http.post('/api/hub/publish', {hub_unique_code: $scope.hub.hub_unique_code}).then(function(data) {
+          $scope.showPublish = false;
+          $('#publishPopup').modal('hide');
+            $timeout( function(){
+                $state.go('root.hubs');
+            }, 1000 );
+
+        }, function(response) {
+          var msg = response.data.error || 'Couldn\'t publish your hub, please try again';
+          swalService.showErrorMsg(msg);
+          $('#publishPopup').modal('hide');
+        });
+      }
+    };
+
+  }]);
+
+
+  module.controller('hubStepTwoEditController', ['$scope', '$state', '$http', 'swalService', 'hub', function($scope, $state, $http, swalService, hub) {
+
+
+    $scope.hub = hub;
+
+    $scope.$on('validate', function(e) {
+      $scope.validate();
+    });
+  
+    $scope.validate = function() {
+      $scope.$emit('HubMoveNext');
+    };
+
+    $scope.subproject_list = [];
+    $scope.hub_subproject_items = []
+    $scope.options_dictionary = {}
+  
+  
+      $scope.add_tutorial_text = "Update Hub Subprojects";
+
+      $scope.visitSubProjectPage = function(subproject_id){
+        var project_code = $scope.options_dictionary[parseInt(subproject_id)].unique_code
+        var link = "kioskProject.html#/kioskStart/" + project_code;
+        window.open(link); 
+      }
+        
+      //Add subproject info
+      $scope.addSubProjectItem = function(){
+          $scope.hub_subproject_items.push({
+            subproject_id: null,
+            category:null
+          });
+          console.log($scope.hub_subproject_items);
+      };
+  
+      $scope.deleteSubProjectItem = function(index) {
+          $scope.hub_subproject_items.splice(index, 1);
+      };
+  
+      //get the list of subprojects to choose from
+      $scope.fetchSubProjectList = function(){
+              $http.get('/api/user/projects' ).then(function (sdata) {
+                $scope.subproject_list  = sdata.data;
+                $scope.subproject_list.forEach(function(item){
+                  var templ  = JSON.parse(item.template);
+                  delete item.template;
+                  item.template = templ;
+                  $scope.options_dictionary[item.id] = item;
+                })
+              });
+      };
+  
+      //TODO: Store project codes
+      $scope.setSubProjectItems = function(){
+
+        if ($scope.hub_subproject_items.length < 2){
+          swalService.showErrorMsg("You will need at least two subprojects to make a hub!");
+        } else {
+          var projects_to_send = [];
+          var categories_to_send = [];
+          $scope.hub_subproject_items.forEach(function(item){
+            projects_to_send.push($scope.options_dictionary[parseInt(item.subproject_id)])
+            if (item.category){
+              categories_to_send.push(item.category)
+            }
+          })  
+          if (categories_to_send.length != $scope.hub_subproject_items.length){
+            swalService.showErrorMsg("You have to select one category for each subproject.");
+          } else {
+            $http.post('/api/hub/addSubprojectItems',
+            {
+                'hub_unique_code': $scope.hub.hub_unique_code,
+                'subproject_items': projects_to_send,
+                'categories_items': categories_to_send
+            }).then(function () {
+
+            //send message we good
+            swal({
+                title: 'Success!',
+                confirmButtonColor: '#9cdc1f',
+                allowOutsideClick: true,
+                text: 'Subprojects added!',
+                type: 'success'
+            });
+            $scope.hub.can_be_published = true;
+            
+
+        }, function (err) {
+            swalService.showErrorMsg(err);
+        })
+    }
+          }
+            
+
+      };
+      $scope.fetchSubProjectList();
+      //we are in editing, we already have info, let's populate the fields:
+      var existingCodes = $scope.hub.project_codes.split(",");
+      var existingCategories = $scope.hub.results_labels.split(",");
+      console.log(existingCodes)
+      for (var i = 0; i < existingCodes.length; i++) {
+        $scope.hub_subproject_items.push({
+          subproject_id: existingCodes[i],
+          category:existingCategories[i]
+        });
+      }
+      console.log($scope.hub_subproject_items)
+
+  
+  }]);
+
+  module.controller('hubStepOneEditController', ['$scope', '$state', '$http', 'swalService', 'hub',
+  function($scope, $state, $http, swalService, hub) {
+
+    $scope.hub = hub;
+    console.log(hub);
+    var invalid_characters = ['\\','/',':','?','\"','<','>','|'];
+    $scope.has_external_signup = false;
+
+    if ($scope.hub.hasOwnProperty("external_sign_up") && $scope.hub.external_sign_up ){
+        $scope.has_external_signup = true;
+    }
+
+    $scope.$on('validate', function(e) {
+      $scope.validate();
+    });
+
+    $scope.validate = function() {
+      if (!$scope.hub.name || !$scope.hub.description || !$scope.hub.url_name) {
+        $scope.showErr = true;
+        swalService.showErrorMsg('Please enter a name, a url name and description for the  hub project.');
+      } else if (  invalid_characters.some(el => $scope.hub.url_name.includes(el))) {
+          $scope.showErr = true;
+          swalService.showErrorMsg('URL shortcut cannot contain the following characters: \n' + invalid_characters.join(','));
+      } else if ($scope.has_external_signup && ($scope.hub.external_sign_up === "" || !$scope.hub.external_sign_up)){
+          $scope.showErr = true;
+          swalService.showErrorMsg('Please enter valid URL for external signup form.');
+      }
+
+      else {
+        $scope.createHubProject();
+      }
+    };
+
+    
+
+    $scope.createHubProject = function() {
+      
+        var fd = new FormData();
+        if ($scope.coverPic) {
+          fd.append('file', $scope.coverPic);
+        }
+        fd.append('hub_unique_code', $scope.hub.hub_unique_code);
+        fd.append('name', $scope.hub.name);
+        fd.append('description', $scope.hub.description);
+        fd.append('url_name', $scope.hub.url_name);
+          if ($scope.has_external_signup){
+              fd.append('external_sign_up', $scope.hub.external_sign_up);
+          }
+
+          var link = '/api/hub/edit' 
+          $http.post(link, fd, {
+          transformRequest: angular.identity,
+          headers: {'Content-Type': undefined}
+        }).then(function(response) {
+          //console.log($scope.hub)
+          $scope.$emit('HubMoveNext');
+        }, function(response) {
+          var msg = response.data.error || 'Couldn\'t create the hub project';
+          //if we got a duplicate entry, it's because of the short name
+          if (msg == "ER_DUP_ENTRY") {
+            msg = 'A project with the same url name already exists!'
+          }
+          console.log(response)
+          swalService.showErrorMsg(msg);
+        });
+      
+    };
+
+    var handleImage = function(f) {
+      var canvas = document.getElementById('imageCanvas');
+      var ctx = canvas.getContext('2d');
+      var reader = new FileReader();
+      reader.onload = function(event) {
+        var img = new Image();
+        img.onload = function() {
+          canvas.width = img.width;
+          canvas.height = img.height;
+          ctx.drawImage(img, 0, 0);
+        };
+        img.src = event.target.result;
+      };
+      reader.readAsDataURL(f);
+    };
+
+    $scope.$watch('coverPic', function() {
+      if ($scope.coverPic) {
+        handleImage($scope.coverPic);
+      }
+    });
+
+  }]);
+  
 module.controller('userProfileController', ['$scope','$http', '$state', 'projectCreators', function($scope, $http, $state, projectCreators) {
     $scope.projects = {};
 

--- a/public/script/app.js
+++ b/public/script/app.js
@@ -353,6 +353,7 @@ module.config(function($stateProvider, $urlRouterProvider, $httpProvider) {
     }
   });
 
+
   $stateProvider.state({
     name: 'root.project',
     url: '/project/view/:id',
@@ -725,6 +726,56 @@ module.config(function($stateProvider, $urlRouterProvider, $httpProvider) {
       }]
     }
   });
+
+  // HUB PROJECTS
+
+
+  $stateProvider.state({
+    name: 'root.hubs',
+    url: '/hubs',
+    templateUrl: 'templates/project/hubsPageTemplate.html',
+    controller: 'hubsPageController',
+    resolve: {
+      hubs: ['$http', function($http) {
+        return $http.get('/api/user/hubs').then(function(data) {
+          return data.data;
+        }).catch(function(error) {
+          return undefined;
+        });
+      }]
+    }
+  });
+
+  $stateProvider.state({
+    name: 'root.hubProjectCreation',
+    url: '/project/new',
+    templateUrl: 'templates/userProfile/newHubProjectTemplate.html',
+    controller: 'hubProjectCreationController',
+    abstract: true
+  });
+
+  $stateProvider.state({
+    name: 'root.hubProjectCreation.step1',
+    url: '/hubStep1',
+    views: {
+      'createProjChildView': {
+        templateUrl: 'templates/userProfile/hubProjectCreation/step1.html',
+        controller: 'hubStepOneController'
+      }
+    }
+  });
+
+  $stateProvider.state({
+    name: 'root.hubProjectCreation.step2',
+    url: '/hubStep2',
+    views: {
+      'createProjChildView': {
+        templateUrl: 'templates/userProfile/hubProjectCreation/step2.html',
+        controller: 'hubStepTwoController'
+      }
+    }
+  });
+  
 
 
 
@@ -2163,6 +2214,341 @@ module.controller('projectsPageController', ['$scope', 'userData', 'projects', '
 
 
   }]);
+
+
+module.controller('hubsPageController', ['$scope', 'userData', 'hubs', '$timeout', '$http', 'swalService',
+  '$state', 'projectCreators', function($scope, userData, hubs, $timeout, $http, swalService, $state, projectCreators) {
+
+    $scope.hubs = hubs;
+  
+    var startTaskPath = window.location.protocol + '//' + window.location.host + '/hub/';
+
+    var getPathToStart = function(code) {
+      return startTaskPath + code;
+    };
+
+    var showLinkModal = $('#show-link-modal');
+    $scope.showLink = function(hub) {
+        $scope.link = getPathToStart(hub['url_name']);
+        showLinkModal.modal('show');
+    };
+
+    $scope.copyToClip = function() {
+      $('#link-text-inp').select();
+      try {
+        document.execCommand('copy');
+        $scope.showCopiedMsg = true;
+        $timeout(function() {
+          $scope.showCopiedMsg = false;
+          showLinkModal.modal('hide');
+        }, 2000);
+      } catch (err) {
+        alert('Your browser doesn\'t support this feature yet. Please press ctrl+c to copy');
+      }
+    };
+
+    //Edit Hubs
+    $scope.goToHubEdit = function(hub) {
+      $state.go('root.hubProjectEdit.step1', {hub: hub, id: hub.id});
+    };
+
+
+        if($scope.user.is_creator == 1) {$scope.allowProject = true}
+        else {$scope.allowProject = false}
+
+
+
+
+  }]);
+
+
+module.controller('hubProjectCreationController', ['$scope', '$http', '$state', '$timeout', 'swalService', 'projectCreators',
+  function($scope, $http, $state,$timeout, swalService, projectCreators) {
+    
+    
+    $scope.goTo = function(to) {
+      if ($scope.hub.id) {
+        $state.go(to);
+      }
+    };
+
+    $scope.isActive = function(stateName) {
+      return $state.current && $state.current.name == stateName;
+    };
+
+    $scope.getNextText = function() {
+      if ($state.current && $state.current.name == 'root.hubProjectCreation.step2') {
+        return 'Publish';
+      } else {
+        return 'Next';
+      }
+    };
+
+    $scope.goNext = function() {
+
+      if ($state.current && $state.current.name == 'root.hubProjectCreation.step2') {
+        $scope.openPublishPopup();
+      } else {
+        $scope.$broadcast('validate');
+      }
+    };
+
+    $scope.hub = {};
+    $scope.hub.editing = false;
+    $scope.hub.task = {
+      options: []
+    };
+
+    
+    $scope.showPublish = true;
+    $scope.$on('HubMoveNext', function(e, d) {
+      var curr = $state.current.name;
+      var stateMap = {
+        'root.hubProjectCreation.step1': 'root.hubProjectCreation.step2'
+        
+      };
+      try {
+        $state.go(stateMap[curr], {hub: $scope.hub});
+      }
+      catch (e) {
+
+      }
+    });
+    $scope.verifyCanPublish = function() {
+      return $scope.hub.can_be_published  ;
+    };
+
+    $scope.verifyCanImportData = function() {
+      return $scope.project.id && $scope.project.templateSaved;
+    };
+
+    $scope.openPublishPopup = function() {
+      if ($scope.verifyCanPublish()) {
+        $('#publishPopup').modal('show');
+      } else {
+        swalService.showErrorMsg('Please make sure you\'ve filled up the required details before you try to publish.');
+      }
+    };
+
+    $scope.publish = function() {
+      if ($scope.hub.hub_unique_code) {
+        $http.post('/api/hub/publish', {hub_unique_code: $scope.hub.hub_unique_code}).then(function(data) {
+          $scope.showPublish = false;
+          $('#publishPopup').modal('hide');
+            $timeout( function(){
+                $state.go('root.hubs');
+            }, 1000 );
+
+        }, function(response) {
+          var msg = response.data.error || 'Couldn\'t publish your hub, please try again';
+          swalService.showErrorMsg(msg);
+          $('#publishPopup').modal('hide');
+        });
+      }
+    };
+
+
+  }]);
+
+
+module.controller('hubStepOneController', ['$scope', '$state', '$http', 'swalService',
+  function($scope, $state, $http, swalService) {
+
+
+    var invalid_characters = ['\\','/',':','?','\"','<','>','|'];
+    $scope.has_external_signup = false;
+
+    if ($scope.hub.hasOwnProperty("external_sign_up")){
+        $scope.has_external_signup = true;
+    }
+
+    $scope.$on('validate', function(e) {
+      $scope.validate();
+    });
+
+    $scope.validate = function() {
+
+
+      if (!$scope.hub.name || !$scope.hub.description || !$scope.hub.url_name) {
+        $scope.showErr = true;
+        swalService.showErrorMsg('Please enter a name, a url name and description for the  hub project.');
+      } else if (  invalid_characters.some(el => $scope.hub.url_name.includes(el))) {
+          $scope.showErr = true;
+          swalService.showErrorMsg('URL shortcut cannot contain the following characters: \n' + invalid_characters.join(','));
+      } else if ($scope.has_external_signup && ($scope.hub.external_sign_up === "" || !$scope.hub.external_sign_up)){
+          $scope.showErr = true;
+          swalService.showErrorMsg('Please enter valid URL for external signup form.');
+      }
+
+      else {
+        $scope.createHubProject();
+      }
+    };
+
+    $scope.createHubProject = function() {
+      if ($scope.hub.id) {
+        $scope.$emit('moveNext');
+      } else {
+        var fd = new FormData();
+        if ($scope.coverPic) {
+          fd.append('file', $scope.coverPic);
+        }
+        fd.append('name', $scope.hub.name);
+        fd.append('description', $scope.hub.description);
+          fd.append('url_name', $scope.hub.url_name);
+          if ($scope.has_external_signup){
+              fd.append('external_sign_up', $scope.hub.external_sign_up);
+          }
+
+
+          $http.post('/api/hub/add', fd, {
+          transformRequest: angular.identity,
+          headers: {'Content-Type': undefined}
+        }).then(function(response) {
+          var data = response.data;
+          $scope.hub.id = data.id;
+          $scope.hub['hub_unique_code'] = data.hub_unique_code;
+          //console.log($scope.hub)
+          $scope.$emit('HubMoveNext');
+        }, function(response) {
+          var msg = response.data.error || 'Couldn\'t create the hub project';
+          //if we got a duplicate entry, it's because of the short name
+          if (msg == "ER_DUP_ENTRY") {
+            msg = 'A project with the same url name already exists!'
+          }
+          console.log(response)
+          swalService.showErrorMsg(msg);
+        });
+      }
+    };
+
+    var handleImage = function(f) {
+      var canvas = document.getElementById('imageCanvas');
+      var ctx = canvas.getContext('2d');
+      var reader = new FileReader();
+      reader.onload = function(event) {
+        var img = new Image();
+        img.onload = function() {
+          canvas.width = img.width;
+          canvas.height = img.height;
+          ctx.drawImage(img, 0, 0);
+        };
+        img.src = event.target.result;
+      };
+      reader.readAsDataURL(f);
+    };
+
+    $scope.$watch('coverPic', function() {
+      if ($scope.coverPic) {
+        handleImage($scope.coverPic);
+      }
+    });
+
+  }]);
+
+
+
+  module.controller('hubStepTwoController', ['$scope', '$state', '$http', 'swalService', function($scope, $state, $http, swalService) {
+
+    $scope.$on('validate', function(e) {
+      $scope.validate();
+    });
+  
+    $scope.validate = function() {
+      $scope.$emit('HubMoveNext');
+    };
+
+    $scope.subproject_list = [];
+    $scope.hub_subproject_items = []
+    $scope.options_dictionary = {}
+  
+  
+      $scope.add_tutorial_text = "Add Subprojects to Hub";
+
+      $scope.visitSubProjectPage = function(subproject_id){
+        var project_code = $scope.options_dictionary[parseInt(subproject_id)].unique_code
+        var link = "kioskProject.html#/kioskStart/" + project_code;
+        window.open(link); 
+      }
+        
+      //Add subproject info
+      $scope.addSubProjectItem = function(){
+          $scope.hub_subproject_items.push({
+            subproject_id: null,
+            category:null
+          });
+          console.log($scope.hub_subproject_items);
+      };
+  
+      $scope.deleteSubProjectItem = function(index) {
+          $scope.hub_subproject_items.splice(index, 1);
+      };
+  
+      //get the list of subprojects to choose from
+      $scope.fetchSubProjectList = function(){
+              $http.get('/api/user/projects' ).then(function (sdata) {
+                $scope.subproject_list  = sdata.data;
+                $scope.subproject_list.forEach(function(item){
+                  var templ  = JSON.parse(item.template);
+                  delete item.template;
+                  item.template = templ;
+                  $scope.options_dictionary[item.id] = item;
+                })
+              });
+      };
+  
+      //TODO: Store project codes
+      $scope.setSubProjectItems = function(){
+
+        if ($scope.hub_subproject_items.length < 2){
+          swalService.showErrorMsg("You will need at least two subprojects to make a hub!");
+        } else {
+          var projects_to_send = [];
+          var categories_to_send = [];
+          $scope.hub_subproject_items.forEach(function(item){
+            projects_to_send.push($scope.options_dictionary[parseInt(item.subproject_id)])
+            if (item.category){
+              categories_to_send.push(item.category)
+            }
+          })  
+          if (categories_to_send.length != $scope.hub_subproject_items.length){
+            swalService.showErrorMsg("You have to select one category for each subproject.");
+          } else {
+            $http.post('/api/hub/addSubprojectItems',
+            {
+                'hub_unique_code': $scope.hub.hub_unique_code,
+                'subproject_items': projects_to_send,
+                'categories_items': categories_to_send
+            }).then(function () {
+
+            //send message we good
+            swal({
+                title: 'Success!',
+                confirmButtonColor: '#9cdc1f',
+                allowOutsideClick: true,
+                text: 'Subprojects added!',
+                type: 'success'
+            });
+            $scope.hub.can_be_published = true;
+            
+
+        }, function (err) {
+            swalService.showErrorMsg(err);
+        })
+    }
+          }
+            
+
+      };
+  
+    
+  
+  
+      $scope.fetchSubProjectList();
+  
+  }]);
+
+
 
 module.controller('userProfileController', ['$scope','$http', '$state', 'projectCreators', function($scope, $http, $state, projectCreators) {
     $scope.projects = {};

--- a/public/script/kiosk.js
+++ b/public/script/kiosk.js
@@ -1989,7 +1989,7 @@ module.controller('resultsHubController',
         $scope.map_patterns_projects = {}
 
         //STEP 1: get hub information        
-        $http.get('/api/project/getHubInfo/' + $stateParams.hub_code).then(function(hub_data) {
+        $http.get('/api/project/getHubInfoURL/' + $stateParams.hub_code).then(function(hub_data) {
 
             $scope.hub_data = hub_data.data[0]; //all the hub data
             //get the labels we do the maps from the hub:
@@ -3088,7 +3088,7 @@ module.controller('hubProjectController', ['$window','$scope','$location','$stat
         }
 
         //start: get hub information:
-        $http.get('/api/project/getHubInfo/' + $stateParams.hub_code).then(function(hub_data) {
+        $http.get('/api/project/getHubInfoURL/' + $stateParams.hub_code).then(function(hub_data) {
 
             $scope.hub_data = hub_data.data[0];
             $scope.hub_title = $scope.hub_data.name;

--- a/public/script/kiosk.js
+++ b/public/script/kiosk.js
@@ -243,6 +243,7 @@ module.config(function($stateProvider, $urlRouterProvider, $cookiesProvider) {
         controller: 'landlossResultsController'
     });
 
+
     $stateProvider.state({
         name: 'hgProject',
         url: '/hg_landloss',
@@ -262,6 +263,47 @@ module.config(function($stateProvider, $urlRouterProvider, $cookiesProvider) {
         },
         //templateUrl: 'templates/kiosk/appDefault.html',
         controller: 'landlossController'
+    });
+
+    $stateProvider.state({
+        name: 'hubProject',
+        url: '/hubPage/:hub_code',
+        params: {
+            hub_project: true
+        },
+        views: {
+            nav: {
+                templateUrl: './navbar.html'
+            },
+            content: {
+                templateUrl: 'templates/kiosk/appHubProject.html',
+            },
+            footer: {
+                templateUrl: '../footer.html'
+            }
+        },
+        controller: 'hubProjectController'
+    });
+
+
+    $stateProvider.state({
+        name: 'resultsHubProject',
+        url: '/resultsHub/:hub_code',
+        params: {
+            hub_project: true
+        },
+        views: {
+            nav: {
+                templateUrl: './navbar.html'
+            },
+            content: {
+                templateUrl: 'hubResults.html'
+            },
+            footer: {
+                templateUrl: '../footer.html'
+            }
+        },
+        controller: 'resultsHubController'
     });
 
 
@@ -1809,6 +1851,186 @@ module.controller('landlossResultsController',
     });
 
 
+module.controller('resultsHubController',
+    function($scope, $http, $window,$stateParams,$timeout,$location,$sce,NgMap) {
+
+
+        //change this if we want gridMap instead of heatMap
+        $scope.gridMap = false;
+
+        $scope.successProject = false;
+        $scope.showMap = false;
+
+        $window.document.title ="Results";
+
+        $scope.getExternalFrame = function(link){
+            return  $sce.trustAsResourceUrl(link)
+        };
+
+
+        $scope.point_array =  ['/images/markers/marker_green2.svg',
+            '/images/markers/marker_yellow2.svg',
+            '/images/markers/marker_orange2.svg',
+            '/images/markers/marker_red2.svg',
+            '/images/markers/marker_blue2.svg',
+            '/images/markers/marker_purple2.svg',
+            '/images/markers/marker_grey.svg'];
+
+        $scope.hex_array = ['#9cdc1f',
+            '#FFF200',
+            '#F7941D',
+            '#ff0000',
+            '#0072BC',
+            '#8a2be2'
+        ];
+
+        $scope.icon_array =  ['/images/dots/cs_green_dot.svg',
+            '/images/dots/cs_yellow_dot.svg',
+            '/images/dots/cs_orange_dot.svg',
+            '/images/dots/cs_red_dot.svg',
+            '/images/dots/cs_blue_dot.svg',
+            '/images/dots/cs_purple_dot.svg'];
+
+
+
+        //CSV Download Project
+        //TODO: CHANGE
+        $scope.downloadCSVHub = function(){
+            //Download the results
+            location.href = '/api/results/hub_data/csv/' + $stateParams.hub_code
+        };
+
+
+
+        $scope.InitMap = InitMapHub;
+        function InitMapHub (zoom){
+
+            $scope.update_hub_Markers($scope.hub_positives[0],0)
+
+            //generate map
+            //TODO: check back for this center, it might not be adjusted if we make projects in other locations
+            $scope.map1 = {
+                center: {
+                    latitude: parseFloat(29.905498110016907),
+                    longitude: parseFloat(-90.26941133000318)
+                },
+                streetViewControl: false,
+                zoom: zoom,
+                markers: $scope.hubMarkers,
+                markersEvents: {
+                    click: function (marker, eventName, model) {
+                        $scope.map1.window.model = model;
+                        $scope.map1.window.show = true;
+                    }
+                },
+                window: {
+                    marker: {},
+                    show: false,
+                    closeClick: function () {
+                        this.show = false;
+                    },
+                    options: {}
+                }
+            };
+            $scope.successProject = true;
+
+        };
+
+
+        $scope.update_hub_Markers = function (pattern,color_index){
+            $scope.hubMarkers = [];
+            //for every item in the original data, if majority matches picked pattern then add to map:
+            var pointId = 0;
+
+            //change button colors here
+            $scope.hub_positives_buttons[$scope.active_pattern].active = false;
+            $scope.active_pattern = color_index;
+            $scope.hub_positives_buttons[$scope.active_pattern].active = true;
+
+
+            var project_key = $scope.map_patterns_projects[pattern];
+                Object.keys($scope.raw_data).forEach(function (key) {
+
+                    var item = $scope.raw_data[key][project_key];
+                    if (item){
+                        var point_marker = new google.maps.Marker({
+                            latitude: parseFloat(item.lat) ,
+                            longitude: parseFloat(item.lon) ,
+                            title: item.image_url,
+                            id: pointId,
+                            icon: $scope.icon_array[color_index]
+                        });
+    
+    
+                        var image_path = 'api/tasks/getImageFree/' + item.dataset_id + '/' + key  + '.jpg';
+    
+                        point_marker.templateUrl = 'infowindow_templateLandloss.html';
+                        point_marker.templateParameter = {
+                            id:   pointId,
+                            image: image_path,
+                            image_url: item.image_url,
+                            pattern: pattern,
+                            majority_percentage: Math.round(100*item.majority_count/item.total) + "%"
+                        };
+    
+                        if (item.majority === pattern){
+                            $scope.hubMarkers.push(point_marker);
+                        }
+                        pointId = pointId + 1;
+                    }
+
+                });
+
+        };
+        //Options we want to focus on:
+        $scope.hub_positives_buttons = [];
+        $scope.button_pattern_selected = [];
+        $scope.hubMarkers = [];
+        $scope.map_patterns_projects = {}
+
+        //STEP 1: get hub information        
+        $http.get('/api/project/getHubInfo/' + $stateParams.hub_code).then(function(hub_data) {
+
+            $scope.hub_data = hub_data.data[0]; //all the hub data
+            //get the labels we do the maps from the hub:
+            $scope.hub_description = hub_data.description;
+            $scope.hub_title = hub_data.name;
+            $scope.hub_positives = $scope.hub_data.results_labels.split(',');
+            $scope.hub_projects = $scope.hub_data.project_codes.split(',');
+            $scope.active_pattern = 0;
+
+            //make the patterns
+            for (var i = 0; i < $scope.hub_positives.length; i++) {
+                $scope.hub_positives_buttons.push(
+                    {
+                        "pattern":$scope.hub_positives[i],
+                        "color": $scope.hex_array[i],
+                        "active": i == $scope.active_pattern ? true : false
+                }   
+                )
+                $scope.map_patterns_projects[$scope.hub_positives[i]] = parseInt($scope.hub_projects[i])
+                $scope.button_pattern_selected.push('#FFFFFF')
+            }            
+            //do we have external sign up for the hub?
+            $scope.external_signup = $scope.hub_data.external_sign_up;
+
+            //STEP 2: get data for the projects in the hub
+            $http.get('/api/results/hub_data/' + $stateParams.hub_code).then(function(pdata) {
+
+                $scope.raw_data = pdata.data; //all the data    
+                $scope.showMap = true;
+                $scope.InitMap(7);
+    
+            }, function (err) {
+                console.log("Could not fetch subprojects data")
+    
+            });
+
+        }, function (err) {
+            console.log("Could not fetch hub information.")
+
+        });
+    });
 
 module.controller('appController', ['$scope', '$location', function($scope, $location) {
     $scope.params = $location.search();
@@ -2770,15 +2992,143 @@ module.controller('landlossController', ['$window','$scope','$location','$state'
     }]);
 
 
+module.controller('hubProjectController', ['$window','$scope','$location','$state','$stateParams','$http', '$cookies', '$sce',
+    function($window,$scope,$location,$state,$stateParams,$http, $cookies, $sce ){
+        $window.document.title = "Cartoscope";
+
+        $scope.project_title = "";
+        $scope.project_desc = "";
+        $scope.showSource = false;
+        $scope.showCC = false;
+        $scope.proj_data = {};
+        $scope.showConsentMturk = false;
+        $scope.isMturk = false;
+        $scope.hit_id = "kiosk";
+
+        $scope.show_start_button = false;
+
+
+        if ($location.search().hasOwnProperty("trialId")){
+            $scope.isMturk = true
+            $scope.hit_id = $location.search().trialId;
+        }
+
+        $scope.acceptConsent = function() {
+            $scope.showConsentMturk = false;
+            //TODO: We are hiding the navbar because we only want them to do the task
+            //document.getElementById("navB").style.display = "block";
+        };
+
+        //TODO: what about video
+        $scope.showVideo = false;
+        //$scope.video_url = $sce.trustAsResourceUrl('https://www.youtube.com/embed/yCx0H7bBxPk');
+        //$scope.cover_pic_path = 'api/project/getProjectPic/UOYIiFeapnyI';
+
+        //if mturk, first show consent!
+        if ($scope.isMturk) {
+            document.getElementById("navB").style.display = "none";
+            $scope.showConsentMturk = true;
+        }
+
+
+
+        //return random integer [min,max]
+        function randomInt(min,max){
+            return (Math.floor(Math.random() * (max - min + 1) ) + min);
+        }
+
+        $scope.showTerms = function(){
+            $('#termsModal2').appendTo("body").modal('show');
+        }
+
+
+        $scope.assignProject = function() {
+            //console.log($stateParams);
+
+            $scope.params = $location.search();
+
+            var subprojects = $scope.hub_subprojects;
+            var pick_d = randomInt(0,subprojects.length - 1); //pick dataset [start,end]
+            var project_id = parseInt(subprojects[pick_d]);
+            console.log(project_id)
+
+            //check for cookie and set it if it doesnt exist
+            if(!$cookies.get('kiosk')){
+                $cookies.put('kiosk', lil.uuid());
+            }
+
+            $http.get('/api/tasks/getInfoFreeId/' + project_id).then(function(pdata) {
+
+                $scope.proj_data = pdata.data[0];
+                var project_code = $scope.proj_data.unique_code;
+                //getProjects Code dynamically
+                $http.get('/api/anon/startKioskProject/' + project_code).then(function(e, data) {
+                    //console.log('e', e, data);
+                    // $scope.params.project = e.data.projectID;
+                    $scope.workerId = e.data.workerID;
+                    $scope.project = e.data.project;
+                    var type= JSON.parse($scope.proj_data.template);
+                    $scope.projectType = type.selectedTaskType;
+
+                    $http.get('/api/anon/consentKiosk/' + project_code + '?' + 'workerId='+ $scope.workerId+'&cookie='+$cookies.get('kiosk')+'&hitID='+ $scope.hit_id)
+                        .then(function(e, data) {
+                            //console.log('data ', e.data.workerId);
+                            $state.go('examples', {pCode: project_code, workerId: e.data.workerId, projectType: $scope.projectType, kioskId:1, hitId: $scope.hit_id});
+                            //window.location.replace('/api/anon/startKiosk/' + $scope.params.project+ '?workerId='+e.data.workerId+'&kioskId=1');
+                        }, function(err) {
+                            alert('error'+ err);
+                        });
+
+                }, function(err) {
+                    console.log('error', err);
+                });
+            })
+
+
+        }
+
+        //start: get hub information:
+        $http.get('/api/project/getHubInfo/' + $stateParams.hub_code).then(function(hub_data) {
+
+            $scope.hub_data = hub_data.data[0];
+            $scope.hub_title = $scope.hub_data.name;
+            $scope.hub_description = $scope.hub_data.description;
+            $scope.hub_subprojects = $scope.hub_data.project_codes.split(",");
+            $scope.show_start_button = true;
+            $scope.cover_pic = 'default'; //TODO: this should come from hub
+
+            //Get the creator name from the collaborators:
+            //get collaborator info from db, using the first available subproject
+            $http.get('/api/user/getAboutInfoCreator/' + $scope.hub_subprojects[0]).then(function(cdata){
+            if (cdata.data && cdata.data.length >0){
+                $scope.creator = cdata.data[0].name;
+                $scope.showCC = true;
+            }
+        }).catch(function(error){
+            console.log("Could not get collaborator name")
+        });
+
+
+        }, function(err){
+            console.log('error', err);
+        })
+
+
+
+
+
+    }]);
 
 module.controller('navController', ['$scope','$window','$location', '$stateParams', function($scope,$window, $location,$stateParams) {
 
      $scope.setPage = setPage;
 
      $scope.navcode = $stateParams.pCode;
+     $scope.hub_code = $stateParams.hub_code;
 
 
      $scope.hg_landloss = $stateParams.landloss;
+     $scope.hub_project = $stateParams.hub_project;
 
 
      if ($scope.navcode != undefined ){
@@ -2802,6 +3152,10 @@ module.controller('navController', ['$scope','$window','$location', '$stateParam
      if ($scope.hg_landloss){
          $scope.home_link = "kioskProject.html#/hg_landloss"
          $scope.results_link = "#/resultsHG";
+     }
+     if ($scope.hub_project){
+        $scope.home_link = "kioskProject.html#/hubPage/" + $scope.hub_code;
+        $scope.results_link = "#/resultsHub/" + $scope.hub_code;
      }
 
      $scope.showTerms = function(){

--- a/public/templates/kiosk/appHubProject.html
+++ b/public/templates/kiosk/appHubProject.html
@@ -1,0 +1,197 @@
+<div class="container " ng-controller="hubProjectController">
+
+    <div ng-if="!showConsentMturk">
+
+        <div class="row intro"  style="text-align: center">
+            <h1 class="col-sm-12 projectName" style="font-size: 36px;margin-top:50px;"><span style="font-size: 20px;">WELCOME TO</span></br>
+                <b><span style="">{{hub_title}}</span></b></h1>
+        </div>
+
+
+
+    <div ng-if="cover_pic != 'default'" class="row"  style="text-align: center">
+        <br>
+        <a href="https://www.healthygulf.org/" target="_blank">
+        <img ng-src="{{cover_pic_path}}" alt="project logo" style="width: 200px; height: auto"/>
+        </a>
+    </div>
+
+
+
+                <div class="col-sm-12" style="">
+                    <center>
+            <p class="description " style="font-size: 22px; ">
+                {{hub_description}}
+            </p>
+
+            <p class="description " style="font-size: 14px; ">
+                    This material is based upon work supported by the National Science Foundation under Grant No. 1816426. Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.
+            </p>
+
+                    <div ng-hide="showCC"  >
+                        <p ng-if="showSource" >
+                            <a style="color: black;" target="_blank" ng-href="{{image_source}}">
+
+                                <span ng-if="projectType != 'ngs'">Image Source </span>
+                                <span ng-if="projectType == 'ngs'">Click here for Map Source</span>
+                        </a>
+                        </p>
+                    </div>
+                    <div ng-show="showCC"  >
+                        <p ng-if="showSource" >Images from  <a style="color: black;" target="_blank" ng-href="{{image_source}}">
+                            {{creator}}</a> under a <a href="https://creativecommons.org/licenses/by-nc-sa/2.0/" target="_blank">Creative Commons</a> licence.
+                        </p>
+                    </div>
+
+
+            </center>
+        </div>
+
+        <br>
+        <br>
+
+        <div class="row" ng-show="showVideo" style="text-align: center;margin-bottom:20px;">
+
+            <div class="col-lg-3 col-md-3 col-sm-0 col-xs-0"></div>
+
+            <div class="col-lg-6 col-md-6 col-sm-12 col-xs-12" ng-show="video_url.indexOf('youtube') != -1">
+
+            <!--<iframe style="width:600px;height: 400px" ng-src="{{video_url  }}" ></iframe>-->
+                <div class=" video-container" >
+                    <iframe width="560" height="315" class="" ng-src="{{video_url  }}" allowfullscreen></iframe>
+                </div>
+                <small>Watch video for more information</small>
+            </div>
+            <div class="col-lg-3 col-md-3 col-sm-0 col-xs-0"></div>
+
+            <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12" ng-show="video_url.indexOf('youtube') == -1">
+                    <video  class=" border border-primary" width="600" height="400" controls src="{{video_url }}">
+                    </video>
+            </div>
+
+        </div>
+
+        <div ng-if="show_start_button" class="row" style="text-align: center;margin-bottom:20px;">
+            <a ng-click="showTerms()" style="cursor: pointer">
+                <img src="../../images/contribute_btn_on_started.png"
+                     onmouseover="this.src='../../images/contribute_btn_hover_started.png'"
+                     onmouseleave="this.src='../../images/contribute_btn_on_started.png'"
+                     class="contribute"/>
+            </a>
+            <br>
+            <small>Contributing is free and anonymous.</small>
+        </div>
+        <div class="row">
+            <div style="text-align: center;margin: 1%;margin-top:2%;">
+                <p>Cartoscope is open-source. Code available on:</p><a href="https://github.com/crowdgames/cartoscope-backend">
+                    <img src="../../images/github-logo.png" alt="Github" style="width: 150px; height: 50px;"/>
+                </a>
+            </div>
+        </div>
+
+    </div>
+
+    <!--Show terms if coming from MTurk-->
+    <div ng-if="showConsentMturk">
+            <p>Version 2021-2-22</p>
+        <p><b>Northeastern University, Department of: Computer and Information Science; Health Sciences<br />
+            Name of Investigator(s): Seth Cooper; Sara Wylie<em><br />
+            </em>Title of Project: Crowdsourced Data Analysis and Mapping</b></p>
+            <p><b>Request to Participate in Research</b></p>
+            <p>We would like to invite you to participate in a web-based online crowdsourcing task. The task is part of a research study whose purpose is to examine how different variations in the presentation of crowdsourced data analysis and mapping can affect accuracy and engagement. You may receive a different interface with different task parameters than other participants. Your interaction data will be recorded and analyzed. This task should take about 20 minutes to complete.</p>
+            <p>We are asking you to participate in this study because you are a member of Amazon’s Mechanical Turk--a crowdsourcing platform. <b>You must be fluent in English and be at least 18 years old to</b> <b>participate.</b></p>
+            <p><b>The decision to participate in this research project is voluntary.</b> You do not have to participate and you can refuse to participate in the task. Even if you begin the web-based online task, you can stop at any time.</p>
+            <p><b>The risks or discomforts to you for taking part in this study are low</b> and are similar to participating in online websites or surveys.</p>
+            <p><b>There are no direct benefits to you from participating in this study.</b> However, your responses may help us learn more about engagement and performance in citizen science.</p>
+            <p><b>For completing the task, you will receive a payment as indicated on your crowdsourcing platform.</b></p>
+            <p><b>Your part in this study is anonymized to the researchers. The only individually-identifying data we receive from Mechanical Turk are your unique identifier and your country. We will not save your unique identifier</b> <b>or any other information that could be used to uniquely identify you. We will not ask you any questions that could be used to uniquely identify you.</b> Any reports or publications based on this research will use only anonymized data and will not identify you as being affiliated with this project. Data that are completely stripped of identifiable information may be made available online or shared with other researchers. Your de-identified information could be used for future research without additional informed consent. <b>Your data are also stored on Mechanical Turk's servers, and the data there are subject to the Amazon Mechanical Turk Privacy Notice and Participation Agreement.</b></p>
+            <p><b>If you have any questions regarding electronic privacy,</b> please feel free to contact Mark Nardone, NU’s Director of Information Security via phone at 617-373-7901, or via email at privacy@neu.edu.</p>
+            <p><b>If you have any questions about this study,</b> please feel free to contact Seth Cooper, email: seth.cooper.study@gmail.com, or Sara Wylie, email: s.wylie@neu.edu, the people mainly responsible for the research.</p>
+            <p><b>If you have any questions regarding your rights as a research participant,</b> please contact Nan C. Regina, Director, Human Subject Research Protection, Mail Stop: 560-177, Northeastern University, Boston, MA 02115. Tel: 617-373-4588, Email: n.regina@neu.edu. You may call anonymously if you wish.</p>
+            <p><b>This study has been reviewed and approved by the Northeastern University Institutional Review Board (#16-05-17).</b></p>
+            <p>Thank you for your time.</p>
+            <p>Seth Cooper and Sara Wylie</p>
+            <p><b>By clicking on the link below you are indicating that you consent to participate in this study. Please print out a copy of this consent form for your records.</b></p>
+
+            <div class="row" style="text-align: center">
+                <!--<div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">-->
+                <button ng-click="acceptConsent()" class="consent-button">Agree</button>
+                <!--</div>-->
+            </div>
+    </div>
+
+
+    <!--Terms-->
+    <div class="modal" tabindex="-1" role="dialog" id="termsModal2">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Terms & Conditions</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body" style="overflow-y: auto;height: 450px;">
+                    <div id="termsDiv" style="overflow: auto;">
+                            <p>Version 2021-3-22</p>
+                        <p><strong>Northeastern University, Department of: Computer and Information Science; Health Sciences<br />
+                            Name of Investigator(s): Seth Cooper; Sara Wylie<em><br />
+                            </em>Title of Project: Crowdsourced Data Analysis and Mapping</strong></p>
+                            <p><strong>Request to Participate in Research</strong></p>
+                            <p>We would like to invite you to participate in a web-based online crowdsourcing project. The task is part of a research study whose purpose is to examine how different variations in the presentation of crowdsourced data analysis and mapping can affect accuracy and engagement. You may receive a different interface with different task parameters than other participants. Your interaction data will be recorded and analyzed. You may participate as long as you want.</p>
+                            <p>We are asking you to participate in this study because of your interest in this citizen science platform. <strong>You must be fluent in English and at least 18 years old to participate in this project.</strong></p>
+                            <p><strong>The decision to participate in this research project is voluntary.</strong> You do not have to participate and you can refuse to participate in the project. Even if you join the project, you can stop at any time.</p>
+                            <p><strong>You will not be paid for your participation in this study.</strong></p>
+                            <p><strong>The risks or discomforts to you for taking part in this study are low</strong> and are similar to participating in online websites or surveys.</p>
+                            <p><strong>There are no direct benefits to you from participating in this study.</strong> However, your responses may help us learn more about engagement and performance in citizen science.<br />
+                            <br />
+                            By creating an account and/or continuing to use the website or associated communication channels, you acknowledge that:</p>
+                            <ol type="a">
+                                <li>
+                                    <p><strong>Your creation of an account and participation in this project may make you identifiable.</strong> Your username, additional profile information provided by you or derived from your participation, postings, and any images you upload, may be publicly visible on the project’s website and any derived media such as screenshots and demonstrations. Your email will be kept confidential.</p>
+                                    </blockquote></li>
+                                    <li>
+                                        <p><strong>We record interactions with the website, forums, chat, and other communication channels, many of which are public.</strong> We may record your IP address or use cookies. The website also stores your profile information, postings, and interactions. These interactions may be logged and analyzed for research. Please be aware that since areas of the chat and website are publicly available, we are unable to prevent any third party from independently observing these channels.</p>
+                                        </blockquote></li>
+                                        <li>
+                                            <p><strong>We may post surveys on the website.</strong> To better understand who participates in the project, we may occasionally post research surveys on the website. These surveys will ask basic questions about topics such as motivation or demographic information, such as age, gender, and education level. Participation in these surveys is entirely voluntary.</p>
+                                            </blockquote></li>
+                                            <li>
+                                                <p><strong>Data used for research may be made public or shared with collaborators.</strong> Data and analysis may be shown on the website and used in external publications, presentations, promotional materials, and other public venues. Data logged by the website may be shared with domain experts for analysis. Reports or publications based on experimental data gathered during this research will use group data or will anonymize the identity of any individual. Your de-identified information could be used for future research without additional informed consent. In the event that you have made a contribution for which you might be identified, we will contact you for permission before externally associating data analysis with your account name. However, your account name and other account information may appear without explicit permission in external demonstrations of the game or website, including presentations, videos, screenshots, and publications.</p>
+                                                </blockquote></li>
+                                                <li>
+                                                    <p><strong>The project may terminate, suspend, or block your account at any time.</strong> The project may remove any data or postings you have provided.</p>
+                                                    </blockquote></li>
+                                                    <li>
+                                                        <p><strong>Project members may contact you with your account email.</strong>  When creating an account, you provide an email address.  This email address may occasionally be used to contact you in relation to the project.</p>
+                                                        </blockquote></li>
+                                                        <li>
+                                                            <p><strong>You may only upload images that you have rights to do so, and those images become public domain.</strong></p>
+                                                            </blockquote></li>
+                                                            <li>
+                                                                <p><strong>You can opt out of further data gathering at any time.</strong> To do so, discontinue use of the website, forums, chat, and other communication channels associated with the project.</p>
+                                                                </blockquote></li>
+                                                                <li>
+                                                                    <p><strong>This policy may change in the future.</strong> This policy may change at any time. You will be asked to agree to the new terms.</p>
+                                                                    </blockquote></li>
+                            </ol>
+                            <p><strong>If you have any questions regarding electronic privacy,</strong> please feel free to contact Mark Nardone, NU’s Director of Information Security via phone at 617-373-7901, or via email at <span class="underline">privacy@neu.edu</span>.</p>
+                            <p><strong>If you have any questions about this study,</strong> please feel free to contact Seth Cooper, email: <span class="underline">seth.cooper.study@gmail.com</span>, or Sara Wylie, email: <span class="underline">s.wylie@neu.edu</span>, the people mainly responsible for the research.</p>
+                            <p><strong>If you have any questions regarding your rights as a research participant,</strong> please contact Nan C. Regina, Director, Human Subject Research Protection, Mail Stop: 560-177, Northeastern University, Boston, MA 02115. Tel: 617-373-4588, Email: <span class="underline">n.regina@neu.edu</span>. You may call anonymously if you wish.</p>
+                            <p><strong>This study has been reviewed and approved by the Northeastern University Institutional Review Board (#16-05-17).</strong></p>
+                            <p>Thank you for your time.</p>
+                            <p>Seth Cooper and Sara Wylie</p>
+                            <p><strong>By clicking on the link below you are indicating that you consent to participate in this study. Please print out a copy of this consent form for your records.</strong></p>
+
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" data-dismiss="modal" ng-click="assignProject()">Continue</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+</div>
+

--- a/public/templates/project/hubsPageTemplate.html
+++ b/public/templates/project/hubsPageTemplate.html
@@ -1,0 +1,74 @@
+<div class="center-1 project-page-body">
+
+    <div class="content-links-wrapper">
+        <span>
+            <a ui-sref="root.getAllProjects" style="color:white">PROJECTS</a>
+        </span>
+        <span class="circ-sep"></span>
+        <span>
+               <a ui-sref="root.contact" style="color:white" ui-sref-active="active">GROUPS</a>
+            </span>
+        <span class="circ-sep"></span>
+        <span>
+               <a ui-sref="root.contact" style="color:white" ui-sref-active="active">NEWS</a>
+            </span>
+        <span class="circ-sep"></span>
+        <span>
+                <a ui-sref="root.contact" style="color:white" ui-sref-active="active">FORUM</a>
+        </span>
+    </div>
+    <div class="main-body">
+        <div class="search-panel">
+            <div>
+                <div class="search-box">
+                    <input ng-model="searchText"><i class="fa fa-search"></i>
+                </div>
+            </div>
+            <div class="take-space"></div>
+            <div class="button-panel">
+                <button ng-show="{{allowProject}}" ui-sref="root.hubProjectCreation.step1">New Hub Project</button>
+                <button ng-hide="{{allowProject}}" onclick="location.href='mailto:contact@cartosco.pe?subject=Cartoscope: Project Interest'">New Hub Project</button>
+
+            </div>
+        </div>
+
+        <div class="projects-body">
+            <div class="project-row" ng-repeat="hub in hubs| filter:searchText">
+                {{hub.name}}
+
+                <div class="pull-right buttons-box">
+                    <span ng-click="showLink(hub)">View Link</span>
+                    <span> | </span>
+                    <span ng-click="goToHubEdit(hub)">Edit</span>
+                    <!-- <span> | </span>
+                    <span ng-click="duplicateProject(project)">Duplicate</span>
+                    <span> | </span>
+                    <span ng-if='!project.archived' class="archive-btn" ng-click="toggleArchive(project)">
+                        Archive
+                    </span>
+                    <span ng-if="project.archived" class="unarchive-btn" ng-click="toggleArchive(project)">
+                        Un-Archive
+                    </span> -->
+                </div>
+            </div>
+        </div>
+
+        <div class="modal fade" id="show-link-modal" tabindex="-1" role="dialog">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-body slmb">
+                        <div class="input-row">
+                            <input ng-model="link" readonly id="link-text-inp">
+                            <button title="Copy to Clipboard" ng-click="copyToClip()">
+                                <i class="fa fa-clipboard" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                        <div ng-if="showCopiedMsg">
+                            Sucessfully copied to your clipboard
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/public/templates/userProfile/hubEditTemplate.html
+++ b/public/templates/userProfile/hubEditTemplate.html
@@ -1,0 +1,53 @@
+<div class="project-creation-parent">
+    <div class="top-panel">
+
+    </div>
+    <div style="flex: 1;">
+        <div class="tab-body">
+            <div class="tabs" style="width: 100%;align-self: flex-start;">
+                <span ui-sref="root.hubProjectCreation.step1({hub: hub})"
+                      ng-class="{'active': isActive('root.hubEdit.step1')}">
+                    BASIC INFO
+                </span>
+                <span ui-sref="root.hubProjectCreation.step2({hub: hub})"
+                      ng-class="{'active': isActive('root.hubEdit.step2'), 'greyed-out':!hub.id}">
+                    CHOOSE SUBPROJECTS
+                </span>
+                
+                <span style="clear: both;display: none"></span>
+            </div>
+            <div class="steps-view">
+                <div ui-view="createProjChildView">
+
+                </div>
+                <div style="flex-grow:1">
+
+                </div>
+                <div>
+                    <button class="next-btn bottom-btn" ng-click="goNext()" ng-disabled="validate()">{{getNextText()}}
+                    </button>
+                </div>
+            </div>
+
+
+            <div class="modal fade" tabindex="-1" role="dialog" id="publishPopup">
+                <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                    aria-hidden="true">&times;</span></button>
+                            <h4 class="modal-title">Publish</h4>
+                        </div>
+                        <div class="modal-body">
+                            <p>Are you sure?</p>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                            <button type="button" class="btn btn-primary" ng-click="publish()">Publish</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/public/templates/userProfile/hubProjectCreation/step1.html
+++ b/public/templates/userProfile/hubProjectCreation/step1.html
@@ -1,0 +1,74 @@
+<div class="step-1">
+    <div class="row">
+        <div class="col-md-6">
+            <div ng-switch on="::hub.editing">
+                <span>
+                    Hub Project Name*
+                    <i cs-tooltip class="fa fa-question-circle" data-toggle="tooltip"
+                       data-placement="right" style="margin-left: 10px;color: #9cdc1f;"
+                       title="The full title of your hub project. This will be shown in the hub project page in Cartoscope."></i>
+                </span>
+                <input ng-switch-when="true" ng-model="hub.name">
+                <input ng-switch-when="false" ng-model="hub.name">
+            </div>
+            <div ng-switch on="::hub.editing">
+                <span>
+                    URL LINK*
+                </span>
+                <!--Make sure url cannot be edited once added-->
+                <input ng-switch-when="true" ng-model="hub.url_name" readonly>
+                <input ng-switch-when="false" ng-model="hub.url_name">
+            </div>
+            <div>
+                <span>
+                    Description*
+                    <i cs-tooltip class="fa fa-question-circle" data-toggle="tooltip"
+                       data-placement="right" style="margin-left: 10px;color: #9cdc1f;"
+                       title="A full description of your hub project. This will appear in the hub page."></i>
+                </span>
+                <textarea ng-model="hub.description"></textarea>
+            </div>
+
+
+        </div>
+        <div class="col-md-6">
+            <span>
+                Hub Project Image
+                <i cs-tooltip class="fa fa-question-circle" data-toggle="tooltip"
+                   data-placement="right" style="margin-left: 10px"
+                   title="This image will be used to represent your hub project on the website."></i>
+            </span>
+            <label class="file-sel">
+                {{coverPic.name || "Select Image"}}
+                <input type="file" accept="image/*" file-model="coverPic">
+            </label>
+
+            <div>
+                <canvas id="imageCanvas" style="max-height: 200px;width: auto;"></canvas>
+            </div>
+        </div>
+
+
+    </div>
+
+    <div class="row">
+        <span class="txt"><h4>Additional Features: </h4></span>
+    </div>
+
+    <!--external sign up-->
+    <div class="row">
+        <div class="col-md-2">
+            <span>External Sign Up
+            <i cs-tooltip class="fa fa-question-circle" data-toggle="tooltip"
+               data-placement="right" style="margin-left: 19px; color: #9cdc1f;"
+               title="Check if you wish to embed an additional external form, for example for users to sign up.">
+            </i>
+            </span>
+        </div>
+
+        <div class="col-md-1"> <input type="checkbox" ng-model="has_external_signup"  checked="checked"></div>
+        <div class="col-md-4" ng-show="has_external_signup">
+            <input type="url" class="invite" placeholder="External form URL here..." ng-model="hub.external_sign_up">
+        </div>
+    </div>
+</div>

--- a/public/templates/userProfile/hubProjectCreation/step2.html
+++ b/public/templates/userProfile/hubProjectCreation/step2.html
@@ -1,0 +1,147 @@
+<div class="step-4 step-2">
+
+    <div class="holder">
+
+        <span class="txt" >Choose SubProjects</span>
+
+       
+
+        <div ng-show=" !subproject_list.length ">
+            <div class="txt">
+                Waiting for subprojects to load...
+            </div>
+
+        </div>
+
+        <!--Choose from created projects we own-->
+        <div ng-show="subproject_list.length">
+
+            <div ng-repeat="item in hub_subproject_items">
+
+                <div class="row txt" >
+
+                    <div class="col-md-1">
+                        <small>{{$index}}</small>
+                    </div>
+
+                   
+                    <div class="col-md-4" >
+                        <span>
+                        Subproject:
+                            <i cs-tooltip class="fa fa-question-circle" data-toggle="tooltip"
+                               data-placement="right" style="color: #9cdc1f;"
+                               title="Hub subproject, from list of projects you have selected on Cartoscope.">
+                            </i>
+                    </span>
+                    </div>
+                    <div class="col-md-2" >
+                        <span>
+                            Preview <i cs-tooltip class="fa fa-question-circle" data-toggle="tooltip"
+                                      data-placement="right" style="color: #9cdc1f;"
+                                      title="Click on the image to visit the project page."></i>
+                        </span>
+                    </div>
+
+                    <div class="col-md-2" >
+                        <span>
+                        Answer:
+                            <i cs-tooltip class="fa fa-question-circle" data-toggle="tooltip"
+                                         data-placement="right" style="margin-left: 10px;color: #9cdc1f;"
+                                         title="Pick the correct answer for this image.">
+                            </i>
+                        </span>
+                    </div>
+                    
+            
+                    
+
+                </div>
+
+            <div class="row" >
+
+                <div class="col-md-1">
+                    <small>{{$index}}</small>
+                </div>
+
+
+                <!-- Subproject picker-->
+                <div class="col-md-4"   >
+                    <select class="form-control" ng-model="item.subproject_id" >
+                        <option ng-repeat="x in subproject_list" value="{{x.id}}" > {{x.name}}
+                        </option>
+                    </select>
+                </div>
+
+
+                <!-- Visit Link -->
+                <div class="col-md-3"  >
+                    <span style="color: #9cdc1f;" style="top:0px;">
+                        <small>
+                        <a ng-click="visitSubProjectPage(item.subproject_id)"> View Project </a>
+                        </small>
+                    </span>
+                </div>  
+
+                 <!-- pick answer from template-->
+                 <div class="col-md-2" >
+                    <select class="form-control" ng-model="item.category" >
+                        <option ng-repeat="x in options_dictionary[item.subproject_id].template.options" value="{{x.text}}" > {{x.text}}  </option>
+                    </select>
+                </div>
+                
+                
+
+
+                <!--remove answer-->
+                <div class="col-md-2 pull-right">
+                <span class="" ng-click="deleteSubProjectItem($index)" style="color:#DC1F3A;cursor: pointer;">
+                <span class="fa fa-minus"></span>
+                    <span>REMOVE SUBPROJECT</span>
+            </span>
+                </div>
+
+                <br>
+                <br>
+
+            </div>
+
+            <hr>
+            </div>
+            <br>
+            <br>
+
+
+            <div class="row">
+                <div class="col-md-12">
+            <span class="option-add-btn" ng-click="addSubProjectItem()" style="top:0px;">
+                <span class="fa fa-plus"></span>
+                <span>ADD SUBPROJECT</span>
+            </span>
+                </div>
+            </div>
+
+            <br>
+
+            <div class="row">
+                <div class="col-md-4"></div>
+                <div class="col-md-4">
+                    <button style="border: none;"
+                            ng-if="hub_subproject_items.length"
+                            class="next-btn btn btn-primary btn btn-block"
+                            ng-click="setSubProjectItems()" >{{add_tutorial_text}}</button>
+                </div>
+                <div class="col-md-4"></div>
+
+            </div>
+
+
+
+
+        </div>
+
+
+
+    </div>
+
+
+</div>

--- a/public/templates/userProfile/hubProjectCreation/step2.html
+++ b/public/templates/userProfile/hubProjectCreation/step2.html
@@ -67,7 +67,7 @@
                 <!-- Subproject picker-->
                 <div class="col-md-4"   >
                     <select class="form-control" ng-model="item.subproject_id" >
-                        <option ng-repeat="x in subproject_list" value="{{x.id}}" > {{x.name}}
+                        <option ng-repeat="x in subproject_list" value="{{x.id}}" [selected]="x.id == item.subproject_id" > {{x.name}}
                         </option>
                     </select>
                 </div>

--- a/public/templates/userProfile/newHubProjectTemplate.html
+++ b/public/templates/userProfile/newHubProjectTemplate.html
@@ -1,0 +1,53 @@
+<div class="project-creation-parent">
+    <div class="top-panel">
+
+    </div>
+    <div style="flex: 1;">
+        <div class="tab-body">
+            <div class="tabs" style="width: 100%;align-self: flex-start;">
+                <span ui-sref="root.hubProjectCreation.step1({hub: hub})"
+                      ng-class="{'active': isActive('root.hubProjectCreation.step1')}">
+                    BASIC INFO
+                </span>
+                <span ui-sref="root.hubProjectCreation.step2({hub: hub})"
+                      ng-class="{'active': isActive('root.hubProjectCreation.step2'), 'greyed-out':!hub.id}">
+                    CHOOSE SUBPROJECTS
+                </span>
+                
+                <span style="clear: both;display: none"></span>
+            </div>
+            <div class="steps-view">
+                <div ui-view="createProjChildView">
+
+                </div>
+                <div style="flex-grow:1">
+
+                </div>
+                <div>
+                    <button class="next-btn bottom-btn" ng-click="goNext()" ng-disabled="validate()">{{getNextText()}}
+                    </button>
+                </div>
+            </div>
+
+
+            <div class="modal fade" tabindex="-1" role="dialog" id="publishPopup">
+                <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                    aria-hidden="true">&times;</span></button>
+                            <h4 class="modal-title">Publish</h4>
+                        </div>
+                        <div class="modal-body">
+                            <p>Are you sure?</p>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                            <button type="button" class="btn btn-primary" ng-click="publish()">Publish</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/public/templates/userProfile/pageTemplate.html
+++ b/public/templates/userProfile/pageTemplate.html
@@ -31,6 +31,9 @@
                         <div class="main-link" ui-sref="root.projects" ui-sref-active="active">
                             My Projects
                         </div>
+                        <div class="main-link" ui-sref="root.hubs" ui-sref-active="active">
+                            My Hub Projects
+                        </div>
                         <div class="main-link" ng-click="logout()">
                             Sign Out
                         </div>

--- a/public/templates/userProfile/welcomeTemplate.html
+++ b/public/templates/userProfile/welcomeTemplate.html
@@ -55,6 +55,9 @@
                         <div class="main-link" ui-sref="root.projects" ui-sref-active="active">
                             My Projects
                         </div>
+                        <div class="main-link" ui-sref="root.hubs" ui-sref-active="active">
+                            My Hub Projects
+                        </div>
                         <div class="main-link" ng-click="logout()">
                             Sign Out
                         </div>

--- a/routes/hubProjects.js
+++ b/routes/hubProjects.js
@@ -1,0 +1,149 @@
+var express = require('express');
+var router = express.Router();
+var multer = require('multer');
+var validator = require('validator');
+var http = require('http');
+var url = require('url');
+var mailer = require('../scripts/mailer');
+var path = require('path');
+var fs = require('fs');
+var tar = require('tar-fs');
+var randomString = require('randomstring');
+var downloadStatus = require('../db/downloadStatus');
+var exec = require('child_process').exec;
+var spawn = require('child_process').spawn;
+
+var projectDB = require('../db/project');
+var anonUserDB = require('../db/anonUser');
+var userDB = require('../db/user');
+var hubProjectDB = require('../db/hubProject');
+
+var mmm = require('mmmagic');
+var Magic = mmm.Magic;
+var magic = new Magic(mmm.MAGIC_MIME_TYPE);
+
+var isValidImage = require('../constants/imageMimeTypes').validMimeTypes;
+var Promise = require('bluebird');
+var filters = require('../constants/filters');
+var imageCompressionLib = require('../scripts/imageCompression');
+var upload = multer({dest: 'uploads/'});
+var bcrypt = require('bcrypt');
+var salt = process.env.CARTO_SALT;
+
+
+
+
+const storage = multer.diskStorage({
+    destination: function (req, file, cb) {
+
+
+        console.log("in storage disk")
+
+        var path_to_store = path.join(__dirname, '../', 'uploads');
+        cb(null, path_to_store)
+    },
+    filename: function (req, file, cb) {
+        console.log(file)
+        var extArray = file.originalname.split(".");
+        var extension = extArray[extArray.length - 1];
+        cb(null, file.originalname)
+    }
+})
+const fupload = multer({ storage: storage });
+
+
+
+var email = process.env.CARTO_MAILER;
+
+module.exports = router;
+
+
+router.post('/add', [fupload.single('file'), filters.requireLogin, filters.requiredParamHandler(['name', 'description','url_name'])],
+  function(req, res, next) {
+    var body = req.body;
+    var filename = 'default';
+     console.log('body ', body);
+    
+    if (req.file) {
+      filename = req.file.filename;
+        // console.log('file '+ filename);
+
+      magic.detectFile(req.file.path, function(err, result) {
+        if (err) {
+            console.log('result err'+ err);
+            res.status(500).send({error: 'problem with the uploaded image, please try again'});
+          fs.unlink(req.file.path);
+        }
+        
+        if (isValidImage(result)) {
+          fs.renameSync(req.file.path, 'profile_photos/' + filename);
+          generateUniqueProjectCode().then(function(projectCode) {
+            hubProjectDB.addHubProject(body.name, req.session.passport.user.id, body.description, filename, projectCode,body.url_name,body.external_sign_up).then(
+              function(result) {
+                console.log('result '+ result);
+                res.send({id: result.insertId, hub_unique_code: projectCode});
+              }, function(err) {
+                  console.log(err)
+                res.status(500).send({error: err.code});
+              });
+          });
+          
+        } else {
+            console.log(err);
+            res.status(500).send({error: 'problem with the uploaded image, please try again'});
+          fs.unlink(req.file.path);
+        }
+      });
+      
+    } else {
+      generateUniqueProjectCode().then(function(projectCode) {
+        hubProjectDB.addHubProject(body.name, req.session.passport.user.id, body.description, filename, projectCode,body.url_name,body.external_sign_up).then(
+          function(result) {
+            console.log(result)
+            res.send({id: result.insertId, hub_unique_code: projectCode});
+          }, function(err) {
+                console.log(err);
+                res.status(500).send({error: err.code});
+          });
+      });
+    }
+  });
+
+
+  router.post('/addSubprojectItems', function(req, res, next) {
+
+    var hub_code = req.body.hub_unique_code;
+    var subproject_items = req.body.subproject_items;
+    var categories_items = req.body.categories_items;  
+
+    //first delete what we have:
+    hubProjectDB.addSubprojectItems(hub_code,subproject_items,categories_items).then(function(results) {
+
+      res.status(200).send("Subproject items set successfully!")
+
+    }, function(err) {
+        console.log(err)
+        res.status(400).send('Error adding subprojects to hub');
+    });
+});
+
+router.post('/publish', [filters.requireLogin, filters.requiredParamHandler(['hub_unique_code']), upload.any()],
+  function(req, res, next) {
+    hubProjectDB.publish(req.body.hub_unique_code).then(function() {
+      res.send({'status': 'done'});
+    }, function(err) {
+      res.status(500).send({'error': err.code});
+    });
+  });
+
+
+
+  function generateUniqueProjectCode() {
+    return new Promise(function(resolve) {
+      var projectCode = randomString.generate({
+        length: 12,
+        charset: 'alphanumeric'
+      });
+      resolve(projectCode);
+    });
+  }

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -753,10 +753,24 @@ router.get('/getProjectPic/:code', function(req, res, next) {
 
 
 router.get('/getHubInfo/:hub_code', function(req, res, next) {
-  var getProject = projectDB.getHubFromCode(req.params.hub_code);
-  getProject.then(function(project) {
-      if (project.length > 0) {
-          res.send(project)
+  var getProject = hubProjectDB.getHubFromCode(req.params.hub_code);
+  getProject.then(function(hub) {
+      if (hub.length > 0) {
+          res.send(hub)
+      } else {
+          res.status(500).send({error: 'Hub not found'});
+      }
+  }).catch(function(error) {
+      res.status(500).send({error: error.code || 'Hub not found'});
+  });
+
+});
+
+router.get('/getHubInfoURL/:hub_url', function(req, res, next) {
+  var getProject = hubProjectDB.getHubFromURL(req.params.hub_url);
+  getProject.then(function(hub) {
+      if (hub.length > 0) {
+          res.send(hub)
       } else {
           res.status(500).send({error: 'Hub not found'});
       }

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -748,6 +748,22 @@ router.get('/getProjectPic/:code', function(req, res, next) {
 
 });
 
+
+
+router.get('/getHubInfo/:hub_code', function(req, res, next) {
+  var getProject = projectDB.getHubFromCode(req.params.hub_code);
+  getProject.then(function(project) {
+      if (project.length > 0) {
+          res.send(project)
+      } else {
+          res.status(500).send({error: 'Hub not found'});
+      }
+  }).catch(function(error) {
+      res.status(500).send({error: error.code || 'Hub not found'});
+  });
+
+});
+
 function generateUniqueProjectCode() {
   return new Promise(function(resolve) {
     var projectCode = randomString.generate({

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -16,6 +16,7 @@ var spawn = require('child_process').spawn;
 var projectDB = require('../db/project');
 var anonUserDB = require('../db/anonUser');
 var userDB = require('../db/user');
+var hubProjectDB = require('../db/hubProject');
 
 var mmm = require('mmmagic');
 var Magic = mmm.Magic;
@@ -747,6 +748,7 @@ router.get('/getProjectPic/:code', function(req, res, next) {
 
 
 });
+
 
 
 

--- a/routes/results.js
+++ b/routes/results.js
@@ -729,18 +729,6 @@ router.get('/csv/:projectCode', function(req, res, next) {
             //array with results:
             var csv_results =[];
 
-
-            //Get file with renaming convensions from backend:
-            var renamed_csv_path = path.join(__dirname, 'public','/images/files/'+projectCode + '_renamed.csv');
-
-
-
-
-            //d3.csv('http://localhost:'+ CARTO_PORT+'/images/files/'+projectCode + '_renamed.csv', function(csv_data) {
-                checkRenameFileExists(renamed_csv_path, function(csv_data) {
-
-                console.log("After d3")
-
                 //get all the images from the dataset_id
                 projectDB.getDataSetNames2(datasetId).then(function(raw_im_list) {
 
@@ -756,18 +744,6 @@ router.get('/csv/:projectCode', function(req, res, next) {
                         var max_name = '';
                         var o_name = img;
 
-                        //if a renaming guide exists, rename appropriately:
-                        if (fs.existsSync(renamed_csv_path)) {
-                            console.log("File exists");
-                            //find image
-                            var rinfo = filterResponses(
-                                csv_data, {renamed_value: img + '.jpg' });
-                            var renamed = rinfo[0].image_name;
-                            //if renaming exists, rename it
-                            if (renamed) {
-                                o_name = renamed;
-                            }
-                        }
 
                         //Make object for image
                         var counters = {
@@ -818,10 +794,6 @@ router.get('/csv/:projectCode', function(req, res, next) {
                 }, function(err) {
                     res.status(400).send('results could not be generated!!!');
                 });
-            }, err => {
-                console.log(err);
-                res.status(400).send('Results could not be generated!!!');
-            });
         }, function(err) {
             res.status(400).send('Results could not be generated!!!');
         });
@@ -869,11 +841,6 @@ router.get('/csv_heatmap/:projectCode', function(req, res, next) {
             //array with results:
             var csv_results =[];
 
-
-            //Get file with renaming convensions from backend:
-            var renamed_csv_path = path.join(__dirname, 'public','/images/files/'+projectCode + '_renamed.csv');
-            d3.csv('http://localhost:'+ CARTO_PORT+'/images/files/'+projectCode + '_renamed.csv', function(csv_data) {
-
                 //get all the images from the dataset_id
                 projectDB.getDataSetNames2(datasetId).then(function(raw_im_list) {
                     //parse images
@@ -888,18 +855,6 @@ router.get('/csv_heatmap/:projectCode', function(req, res, next) {
                         var o_name = img;
                         var max_color = -1;
 
-                        //if a renaming guide exists, rename appropriately:
-                        if (fs.existsSync(renamed_csv_path)) {
-                            console.log("File exists");
-                            //find image
-                            var rinfo = filterResponses(
-                                csv_data, {renamed_value: img + '.jpg' });
-                            var renamed = rinfo[0].image_name;
-                            //if renaming exists, rename it
-                            if (renamed) {
-                                o_name = renamed;
-                            }
-                        }
 
                         //Make object for image
                         var counters = {
@@ -958,7 +913,6 @@ router.get('/csv_heatmap/:projectCode', function(req, res, next) {
                     console.log(err)
                     res.status(400).send(err);
                 });
-            });
         }, function(err) {
             console.log(err)
             res.status(400).send('Results could not be generated!!!');

--- a/routes/results.js
+++ b/routes/results.js
@@ -447,7 +447,7 @@ router.get('/hg_raw_data/csv', function(req, res, next) {
 router.get('/hub_data/csv/:hub_code', function(req, res, next) {
 
     
-    hubProjectDB.getHubFromCode(req.params.hub_code).then(function(hub_results){
+    hubProjectDB.getHubFromURL(req.params.hub_code).then(function(hub_results){
         var hub_ids = hub_results[0].project_codes.split(',');
         //TODO: WE ARE DEFAULTING TO ONE DATASET ONLY. CHANGE IN FUTURE
         var hub_dataset_id = hub_results[0].dataset_ids.split(',')[0];
@@ -569,9 +569,8 @@ router.get('/cairns_raw_data/csv', function(req, res, next) {
 //Get raw data from all subprojects in a hub
 router.get('/hub_data/:hub_code', function(req, res, next) {
 
-
     //first get the hub info
-    hubProjectDB.getHubFromCode(req.params.hub_code).then(function(hub_results){
+    hubProjectDB.getHubFromURL(req.params.hub_code).then(function(hub_results){
         var hub_ids = hub_results[0].project_codes.split(',');
         //TODO: Right now we default everything to the first dataset id. We need to figure it out in the future
         var hub_dataset_id = hub_results[0].dataset_ids.split(',')[0];

--- a/routes/results.js
+++ b/routes/results.js
@@ -501,6 +501,28 @@ router.get('/cairns_raw_data/csv', function(req, res, next) {
 });
 
 
+//Get raw data from all subprojects in a hub
+router.get('/hub_data/:hub_code', function(req, res, next) {
+
+
+    //first get the hub info
+    projectDB.getHubFromCode(req.params.hub_code).then(function(hub_results){
+        var hub_ids = hub_results[0].project_codes.split(',');
+        var hub_dataset_id = hub_results[0].hub_dataset_id;
+        //then get the data
+        resultDB.getHubRawResultsMultiplebyTextGrouped(hub_ids,hub_dataset_id,true).then(function(results) {
+            res.send(results);
+        }, function(err) {
+            console.log(err)
+            res.status(400).send('raw HG results could not be retrieved');
+        });
+
+    }, function(err){
+        console.log(err)
+        res.status(400).send('Hub info could not be retrieved');
+    })
+    
+});
 
 
 //Get results for project from mturk workers

--- a/routes/results.js
+++ b/routes/results.js
@@ -1,5 +1,6 @@
 var resultDB = require('../db/results');
 var projectDB = require('../db/project');
+var hubProjectDB = require('../db/hubProject');
 var tileDB = require('../db/tileoscope');
 var filters = require('../constants/filters');
 var express = require('express');
@@ -445,12 +446,11 @@ router.get('/hg_raw_data/csv', function(req, res, next) {
 //Get raw HUB data from all projects in the hub
 router.get('/hub_data/csv/:hub_code', function(req, res, next) {
 
-    var hg_ids = [55,56,57,58,59,60];
-    var dataset_id = "0k9ceCYzyqLt1pR";
-
-    projectDB.getHubFromCode(req.params.hub_code).then(function(hub_results){
+    
+    hubProjectDB.getHubFromCode(req.params.hub_code).then(function(hub_results){
         var hub_ids = hub_results[0].project_codes.split(',');
-        var hub_dataset_id = hub_results[0].hub_dataset_id;
+        //TODO: WE ARE DEFAULTING TO ONE DATASET ONLY. CHANGE IN FUTURE
+        var hub_dataset_id = hub_results[0].dataset_ids.split(',')[0];
 
         var today = new Date();
         var dd = today.getDate().toString()
@@ -571,9 +571,10 @@ router.get('/hub_data/:hub_code', function(req, res, next) {
 
 
     //first get the hub info
-    projectDB.getHubFromCode(req.params.hub_code).then(function(hub_results){
+    hubProjectDB.getHubFromCode(req.params.hub_code).then(function(hub_results){
         var hub_ids = hub_results[0].project_codes.split(',');
-        var hub_dataset_id = hub_results[0].hub_dataset_id;
+        //TODO: Right now we default everything to the first dataset id. We need to figure it out in the future
+        var hub_dataset_id = hub_results[0].dataset_ids.split(',')[0];
         //then get the data
         resultDB.getHubRawResultsMultiplebyTextGrouped(hub_ids,hub_dataset_id,true).then(function(results) {
             res.send(results);

--- a/routes/tasks.js
+++ b/routes/tasks.js
@@ -133,6 +133,21 @@ router.get('/getInfoFree/:code', function(req, res, next) {
 
 });
 
+
+router.get('/getInfoFreeId/:id', function(req, res, next) {
+  var getProject = projectDB.getProjectFromId(req.params.id);
+  getProject.then(function(project) {
+      if (project.length > 0) {
+          res.send(project)
+      } else {
+          res.status(500).send({error: 'Project not found'});
+      }
+  }).catch(function(error) {
+      res.status(500).send({error: error.code || 'Project not found'});
+  });
+
+});
+
 router.get('/getInfoId/:id', [filters.requireRegularLogin], function(req, res, next) {
   var getProject = projectDB.getProjectFromId(req.params.id);
   getProject.then(function(project) {

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,6 +1,8 @@
 var express = require('express');
 var userDB = require('../db/user');
 var projectDB = require('../db/project');
+var hubProjectDB = require('../db/hubProject');
+
 var mmm = require('mmmagic');
 var router = express.Router();
 var multer = require('multer');
@@ -248,6 +250,17 @@ router.get('/projects', filters.requireRegularLogin, function(req, res, next) {
   }).catch(function(err) {
     res.status(500).send({
       error: err.code || 'Couldn\'t find projects for the user'
+    });
+  });
+});
+
+router.get('/hubs', filters.requireRegularLogin, function(req, res, next) {
+  var userID = req.session.passport.user.id;
+  hubProjectDB.getAllHubProjectsForUser(userID).then(function(data) {
+    res.send(data);
+  }).catch(function(err) {
+    res.status(500).send({
+      error: err.code || 'Couldn\'t find hub projects for the user'
     });
   });
 });


### PR DESCRIPTION
# New Feature: Hub Projects

Hubs act as a central point for connecting multiple sub-projects into one main project. An example of an existing hub is LLL, which combines 6 subprojects, one for each category we are interested in. The purpose of a hub is to gather all necessary information in one place, taking care of randomly assigning visitors to subprojects, and having a main results page that aggregates results from selected categories across subprojects. 

A new UI is also implemented to easily create hub projects, by choosing from existing projects (at this point, these should all have the same image set [dataset-id]), and then choosing one category from each subproject to be shown in the results page.

# Bug Fixes:
- Fixed a bug that was re-writing project settings for scistarter links and inaturalist integration
- Fixed a bug that was blocking maps to load properly on individual projects.